### PR TITLE
Use X509.Certificate instead of Tls.Core.Cert

### DIFF
--- a/mehari/cgi.ml
+++ b/mehari/cgi.ml
@@ -16,7 +16,7 @@ module Make (Addr : Types.ADDR) : S with type addr := Addr.t = struct
           (* We pick the first one. *)
           Option.map
             (fun (_, d) -> Domain_name.to_string d)
-            (Tls.Core.Cert.hostnames c |> X509.Host.Set.choose_opt)
+            (X509.Certificate.hostnames c |> X509.Host.Set.choose_opt)
     in
     let client_addr = Format.asprintf "%a" Addr.pp (Request.ip req) in
     [|

--- a/mehari/protocol.ml
+++ b/mehari/protocol.ml
@@ -52,7 +52,7 @@ let check_host uri epoch =
   | None -> Error MissingHost
   | Some h -> (
       let hostnames =
-        List.map Tls.Core.Cert.hostnames epoch.Tls.Core.own_certificate
+        List.map X509.Certificate.hostnames epoch.Tls.Core.own_certificate
         |> List.fold_left X509.Host.Set.union X509.Host.Set.empty
         |> X509.Host.Set.to_seq
         |> Seq.map (fun (_, d) -> Domain_name.to_string d)


### PR DESCRIPTION
In the future. the private Tls.Core.Cert (an alias to X509.Certificate) will be removed.