### PR TITLE
Improve and optimize Gemtext support.

### DIFF
--- a/mehari/gemtext.ml
+++ b/mehari/gemtext.ml
@@ -72,7 +72,7 @@ let split_lines text =
   let buf = Buffer.create 8192 in
   let acc = ref [] in
   let cr = ref false in
-  for i = String.length text - 1 downto 0 do
+  for i = 0 to String.length text - 1 do
     match String.unsafe_get text i with
     | '\r' -> cr := true
     | '\n' when !cr ->
@@ -92,7 +92,7 @@ let split_lines text =
   done;
   if !cr then Buffer.add_char buf '\r';
   acc := (Buffer.contents buf, EOF) :: !acc;
-  !acc
+  List.rev !acc
 
 let of_string text =
   let buf = Buffer.create 4096 in
@@ -154,7 +154,7 @@ let paragraph gemtext s =
   let doc = ref [] in
   let cr = ref false in
   let buf = Buffer.create (String.length s) in
-  for i = String.length s - 1 downto 0 do
+  for i = 0 to String.length s - 1 do
     match String.unsafe_get s i with
     | '\r' -> cr := true
     | '\n' when !cr ->
@@ -172,4 +172,5 @@ let paragraph gemtext s =
         Buffer.add_char buf c;
         cr := false
   done;
-  match Buffer.contents buf with "" -> !doc | line -> gemtext line :: !doc
+  List.rev
+  @@ match Buffer.contents buf with "" -> !doc | line -> gemtext line :: !doc

--- a/mehari/gemtext.ml
+++ b/mehari/gemtext.ml
@@ -95,7 +95,7 @@ let split_lines text =
   !acc
 
 let of_string text =
-  let buf = Buffer.create (String.length text) in
+  let buf = Buffer.create 4096 in
   let rec loop acc is_preformat alt = function
     | [] -> List.rev acc
     | (l, feed) :: ls -> (


### PR DESCRIPTION
* Use `Format` mechanism instead of ugly homemade solution (this means that soft wrapping can be used for example)
* Avoid `option` allocation for each Gemtext line regex match and use exception instead 
* Increase initial buffer size
* Avoid useless traversing by traversing string in reverse order